### PR TITLE
Managing DAO Modules

### DIFF
--- a/contracts/v3/adapters/Managing.sol
+++ b/contracts/v3/adapters/Managing.sol
@@ -38,7 +38,6 @@ contract ManagingContract is IManaging, Module, AdapterGuard {
     }
 
     function createModuleChangeRequest(address applicant, bytes32 moduleId, address moduleAddress) override external returns (uint256) {
-        require(isReplaceable(moduleId), "module not replaceable");
         require(moduleAddress != address(0x0), "invalid module address");
 
         IBank bankContract = IBank(dao.getAddress(BANK_MODULE));

--- a/contracts/v3/adapters/Managing.sol
+++ b/contracts/v3/adapters/Managing.sol
@@ -44,6 +44,8 @@ contract ManagingContract is IManaging, Module, AdapterGuard {
         IBank bankContract = IBank(dao.getAddress(BANK_MODULE));
         require(bankContract.isReservedAddress(applicant), "applicant address cannot be reserved");
         require(bankContract.isReservedAddress(moduleAddress), "module address cannot be reserved");
+
+        //FIXME: is there a way to check if the new module implements the module interface properly?
         
         IProposal proposalContract = IProposal(dao.getAddress(PROPOSAL_MODULE));
         uint256 proposalId = proposalContract.createProposal(dao);

--- a/contracts/v3/adapters/Managing.sol
+++ b/contracts/v3/adapters/Managing.sol
@@ -11,7 +11,7 @@ import '../core/interfaces/IBank.sol';
 import '../guards/AdapterGuard.sol';
 import '../utils/SafeMath.sol';
 
-contract ManagingContract is IManaging, Module, AdapterGuard  {
+contract ManagingContract is IManaging, Module, AdapterGuard {
     
     using SafeMath for uint256;
 
@@ -38,8 +38,8 @@ contract ManagingContract is IManaging, Module, AdapterGuard  {
     }
 
     function createModuleChangeRequest(address applicant, bytes32 moduleId, address moduleAddress) override external returns (uint256) {
-        require(moduleAddress != address(0x0), "invalid module address");
         require(isReplaceable(moduleId), "module not replaceable");
+        require(moduleAddress != address(0x0), "invalid module address");
 
         IBank bankContract = IBank(dao.getAddress(BANK_MODULE));
         require(bankContract.isReservedAddress(applicant), "applicant address cannot be reserved");

--- a/contracts/v3/adapters/Onboarding.sol
+++ b/contracts/v3/adapters/Onboarding.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.7.0;
 // SPDX-License-Identifier: MIT
 
 import './interfaces/IOnboarding.sol';
+import '../core/Module.sol';
 import '../core/Registry.sol';
 import '../core/interfaces/IVoting.sol';
 import '../core/interfaces/IProposal.sol';
@@ -10,7 +11,7 @@ import '../core/interfaces/IBank.sol';
 import '../utils/SafeMath.sol';
 import '../guards/AdapterGuard.sol';
 
-contract OnboardingContract is IOnboarding, AdapterGuard {
+contract OnboardingContract is IOnboarding, Module, AdapterGuard {
     using SafeMath for uint256;
 
     struct ProposalDetails {
@@ -24,10 +25,6 @@ contract OnboardingContract is IOnboarding, AdapterGuard {
     uint256 public CHUNK_SIZE;
     uint256 public SHARES_PER_CHUNK;
     mapping(uint256 => ProposalDetails) public proposals;
-
-    bytes32 constant BANK_MODULE = keccak256("bank");
-    bytes32 constant PROPOSAL_MODULE = keccak256("proposal");
-    bytes32 constant VOTING_MODULE = keccak256("voting");
 
     constructor (address _dao, uint256 _CHUNK_SIZE, uint256 _SHARES_PER_CHUNK) {
         dao = Registry(_dao);

--- a/contracts/v3/adapters/interfaces/IManaging.sol
+++ b/contracts/v3/adapters/interfaces/IManaging.sol
@@ -1,0 +1,9 @@
+pragma solidity ^0.7.0;
+
+// SPDX-License-Identifier: MIT
+
+interface IManaging {
+    function createModuleChangeRequest(address applicant, bytes32 moduleId, address moduleAddress) external returns (uint256);
+    function sponsorProposal(uint256 proposalId, bytes calldata data) external;    
+    function processProposal(uint256 proposalId) external;
+}

--- a/contracts/v3/core/DaoFactory.sol
+++ b/contracts/v3/core/DaoFactory.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.7.0;
 
 // SPDX-License-Identifier: MIT
 
+import './Module.sol';
 import './Registry.sol';
 import '../core/interfaces/IVoting.sol';
 import '../core/interfaces/IProposal.sol';
@@ -10,17 +11,11 @@ import '../adapters/Onboarding.sol';
 import '../adapters/Financing.sol';
 import '../core/banking/Bank.sol';
 
-contract DaoFactory {
+contract DaoFactory is Module {
 
     event NewDao(address summoner, address dao);
 
     mapping(bytes32 => address) addresses;
-    bytes32 constant BANK_MODULE = keccak256("bank");
-    bytes32 constant MEMBER_MODULE = keccak256("member");
-    bytes32 constant PROPOSAL_MODULE = keccak256("proposal");
-    bytes32 constant VOTING_MODULE = keccak256("voting");
-    bytes32 constant ONBOARDING_MODULE = keccak256("onboarding");
-    bytes32 constant FINANCING_MODULE = keccak256("financing");
 
     constructor (address memberAddress, address proposalAddress, address votingAddress) {
         addresses[MEMBER_MODULE] = memberAddress;
@@ -33,14 +28,14 @@ contract DaoFactory {
         Registry dao = new Registry();
         BankContract bank = new BankContract(dao);
         //Registering Core Modules
-        dao.updateRegistry(BANK_MODULE, address(bank));
-        dao.updateRegistry(MEMBER_MODULE, addresses[MEMBER_MODULE]);
-        dao.updateRegistry(PROPOSAL_MODULE, addresses[PROPOSAL_MODULE]);
-        dao.updateRegistry(VOTING_MODULE, addresses[VOTING_MODULE]);
+        dao.addModule(BANK_MODULE, address(bank));
+        dao.addModule(MEMBER_MODULE, addresses[MEMBER_MODULE]);
+        dao.addModule(PROPOSAL_MODULE, addresses[PROPOSAL_MODULE]);
+        dao.addModule(VOTING_MODULE, addresses[VOTING_MODULE]);
 
         //Registring Adapters
-        dao.updateRegistry(ONBOARDING_MODULE, address(new OnboardingContract(address(dao), chunkSize, nbShares)));
-        dao.updateRegistry(FINANCING_MODULE, address(new FinancingContract(address(dao))));
+        dao.addModule(ONBOARDING_MODULE, address(new OnboardingContract(address(dao), chunkSize, nbShares)));
+        dao.addModule(FINANCING_MODULE, address(new FinancingContract(address(dao))));
 
         IVoting votingContract = IVoting(addresses[VOTING_MODULE]);
         votingContract.registerDao(address(dao), votingPeriod);

--- a/contracts/v3/core/DaoFactory.sol
+++ b/contracts/v3/core/DaoFactory.sol
@@ -7,9 +7,10 @@ import './Registry.sol';
 import '../core/interfaces/IVoting.sol';
 import '../core/interfaces/IProposal.sol';
 import '../core/interfaces/IMember.sol';
+import '../core/banking/Bank.sol';
 import '../adapters/Onboarding.sol';
 import '../adapters/Financing.sol';
-import '../core/banking/Bank.sol';
+import '../adapters/Managing.sol';
 
 contract DaoFactory is Module {
 
@@ -26,25 +27,26 @@ contract DaoFactory is Module {
     //TODO - do we want to restrict the access to onlyOwner for this function?
     function newDao(uint256 chunkSize, uint256 nbShares, uint256 votingPeriod) external returns (address) {
         Registry dao = new Registry();
-        BankContract bank = new BankContract(dao);
+        address daoAddress = address(dao);
         //Registering Core Modules
-        dao.addModule(BANK_MODULE, address(bank));
+        dao.addModule(BANK_MODULE, address(new BankContract(dao)));
         dao.addModule(MEMBER_MODULE, addresses[MEMBER_MODULE]);
         dao.addModule(PROPOSAL_MODULE, addresses[PROPOSAL_MODULE]);
         dao.addModule(VOTING_MODULE, addresses[VOTING_MODULE]);
 
         //Registring Adapters
-        dao.addModule(ONBOARDING_MODULE, address(new OnboardingContract(address(dao), chunkSize, nbShares)));
-        dao.addModule(FINANCING_MODULE, address(new FinancingContract(address(dao))));
+        dao.addModule(ONBOARDING_MODULE, address(new OnboardingContract(daoAddress, chunkSize, nbShares)));
+        dao.addModule(FINANCING_MODULE, address(new FinancingContract(daoAddress)));
+        dao.addModule(MANAGING_MODULE, address(new ManagingContract(daoAddress)));
 
         IVoting votingContract = IVoting(addresses[VOTING_MODULE]);
-        votingContract.registerDao(address(dao), votingPeriod);
+        votingContract.registerDao(daoAddress, votingPeriod);
 
         IMember memberContract = IMember(addresses[MEMBER_MODULE]);
         memberContract.updateMember(dao, msg.sender, 1);
 
-        emit NewDao(msg.sender, address(dao));
+        emit NewDao(msg.sender, daoAddress);
 
-        return address(dao);
+        return daoAddress;
     }
 }

--- a/contracts/v3/core/Module.sol
+++ b/contracts/v3/core/Module.sol
@@ -1,0 +1,22 @@
+pragma solidity ^0.7.0;
+
+// SPDX-License-Identifier: MIT
+
+abstract contract Module {
+
+    //Replaceable Modules
+    bytes32 constant BANK_MODULE = keccak256("bank");
+    bytes32 constant MEMBER_MODULE = keccak256("member");
+    bytes32 constant PROPOSAL_MODULE = keccak256("proposal");
+    bytes32 constant VOTING_MODULE = keccak256("voting");
+    bytes32 constant ONBOARDING_MODULE = keccak256("onboarding");
+    bytes32 constant FINANCING_MODULE = keccak256("financing");
+
+    //NonReplaceable Modules
+    bytes32 constant MANAGING_MODULE = keccak256("managing");
+
+    function isReplaceable(bytes32 moduleId) internal pure returns (bool) {
+        return moduleId == BANK_MODULE || moduleId == MEMBER_MODULE || moduleId == PROPOSAL_MODULE 
+        || moduleId == VOTING_MODULE || moduleId == ONBOARDING_MODULE || moduleId == FINANCING_MODULE;
+    }
+}

--- a/contracts/v3/core/Module.sol
+++ b/contracts/v3/core/Module.sol
@@ -4,19 +4,12 @@ pragma solidity ^0.7.0;
 
 abstract contract Module {
 
-    //Replaceable Modules
     bytes32 constant BANK_MODULE = keccak256("bank");
     bytes32 constant MEMBER_MODULE = keccak256("member");
     bytes32 constant PROPOSAL_MODULE = keccak256("proposal");
     bytes32 constant VOTING_MODULE = keccak256("voting");
     bytes32 constant ONBOARDING_MODULE = keccak256("onboarding");
     bytes32 constant FINANCING_MODULE = keccak256("financing");
-
-    //NonReplaceable Modules
     bytes32 constant MANAGING_MODULE = keccak256("managing");
-
-    function isReplaceable(bytes32 moduleId) internal pure returns (bool) {
-        return moduleId == BANK_MODULE || moduleId == MEMBER_MODULE || moduleId == PROPOSAL_MODULE 
-        || moduleId == VOTING_MODULE || moduleId == ONBOARDING_MODULE || moduleId == FINANCING_MODULE;
-    }
+    
 }

--- a/contracts/v3/core/Registry.sol
+++ b/contracts/v3/core/Registry.sol
@@ -19,25 +19,24 @@ contract Registry is Ownable {
         _;
     }
 
-    function isModule(address module) public view returns (bool) {
-        return inverseRegistry[module] != bytes32(0);
-    }
-
     function addModule(bytes32 moduleId, address moduleAddress) onlyModule external {
-        require(moduleId != bytes32(0), "moduleId must not be empty");
-        require(moduleAddress != address(0x0), "moduleAddress must not be empty");
+        require(moduleId != bytes32(0), "module id must not be empty");
+        require(moduleAddress != address(0x0), "module address must not be empty");
         registry[moduleId] = moduleAddress;
         inverseRegistry[moduleAddress] = moduleId;
     }
 
     function removeModule(bytes32 moduleId) onlyModule external {
-        require(moduleId != bytes32(0), "moduleId must not be empty");
-        require(registry[moduleId] != address(0x0), "moduleId not registered");
+        require(moduleId != bytes32(0), "module id must not be empty");
+        require(registry[moduleId] != address(0x0), "module id not registered");
         delete inverseRegistry[registry[moduleId]];
         delete registry[moduleId];
     }
 
-    //TODO - do we need an Adapter for that?
+    function isModule(address module) public view returns (bool) {
+        return inverseRegistry[module] != bytes32(0);
+    }
+
     function getAddress(bytes32 moduleId) view external returns(address) {
         return registry[moduleId];
     }

--- a/contracts/v3/core/Registry.sol
+++ b/contracts/v3/core/Registry.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.7.0;
 
-import '../utils/Ownable.sol';
-
 // SPDX-License-Identifier: MIT
+
+import '../utils/Ownable.sol';
 
 contract Registry is Ownable {
     mapping(bytes32 => address) registry;
@@ -23,14 +23,14 @@ contract Registry is Ownable {
         return inverseRegistry[module] != bytes32(0);
     }
 
-    function updateRegistry(bytes32 moduleId, address moduleAddress) onlyModule external {
+    function addModule(bytes32 moduleId, address moduleAddress) onlyModule external {
         require(moduleId != bytes32(0), "moduleId must not be empty");
         require(moduleAddress != address(0x0), "moduleAddress must not be empty");
         registry[moduleId] = moduleAddress;
         inverseRegistry[moduleAddress] = moduleId;
     }
 
-    function removeRegistry(bytes32 moduleId) onlyModule external {
+    function removeModule(bytes32 moduleId) onlyModule external {
         require(moduleId != bytes32(0), "moduleId must not be empty");
         require(registry[moduleId] != address(0x0), "moduleId not registered");
         delete inverseRegistry[registry[moduleId]];

--- a/contracts/v3/core/proposals/Proposal.sol
+++ b/contracts/v3/core/proposals/Proposal.sol
@@ -3,17 +3,16 @@ pragma solidity ^0.7.0;
 // SPDX-License-Identifier: MIT
 
 import '../Registry.sol';
+import '../Module.sol';
 import '../interfaces/IMember.sol';
 import '../interfaces/IProposal.sol';
 import '../interfaces/IVoting.sol';
 import '../../helpers/FlagHelper.sol';
 import '../../guards/ModuleGuard.sol';
 
-contract ProposalContract is IProposal, ModuleGuard {
+contract ProposalContract is IProposal, Module, ModuleGuard {
+    
     using FlagHelper for uint256;
-
-    bytes32 constant memberModuleId = keccak256("member");
-    bytes32 constant votingModuleId = keccak256("voting");
 
     event SponsorProposal(uint256 proposalId, uint256 proposalIndex, uint256 startingTime);
     event NewProposal(uint256 proposalId, uint256 proposalIndex);
@@ -42,10 +41,10 @@ contract ProposalContract is IProposal, ModuleGuard {
         require(!proposal.flags.isSponsored(), "the proposal has already been sponsored");
         require(!proposal.flags.isCancelled(), "the proposal has been cancelled");
 
-        IMember memberContract = IMember(dao.getAddress(memberModuleId));
+        IMember memberContract = IMember(dao.getAddress(MEMBER_MODULE));
         require(memberContract.isActiveMember(dao, sponsoringMember), "only active members can sponsor someone joining");
 
-        IVoting votingContract = IVoting(dao.getAddress(votingModuleId));
+        IVoting votingContract = IVoting(dao.getAddress(VOTING_MODULE));
         uint256 votingId = votingContract.startNewVotingForProposal(dao, proposalId, votingData);
         
         emit SponsorProposal(proposalId, votingId, block.timestamp);

--- a/contracts/v3/core/voting/OffchainVoting.sol
+++ b/contracts/v3/core/voting/OffchainVoting.sol
@@ -4,14 +4,13 @@ pragma experimental ABIEncoderV2;
 // SPDX-License-Identifier: MIT
 
 import '../Registry.sol';
+import '../Module.sol';
 import '../interfaces/IProposal.sol';
 import '../interfaces/IMember.sol';
 import '../interfaces/IVoting.sol';
 import '../../helpers/FlagHelper.sol';
 
-contract OffchainVotingContract is IVoting {
-
-    bytes32 constant MEMBER_MODULE = keccak256("member");
+contract OffchainVotingContract is IVoting, Module {
 
     using FlagHelper for uint256;
 

--- a/contracts/v3/core/voting/Voting.sol
+++ b/contracts/v3/core/voting/Voting.sol
@@ -3,13 +3,12 @@ pragma solidity ^0.7.0;
 // SPDX-License-Identifier: MIT
 
 import '../Registry.sol';
+import '../Module.sol';
 import '../interfaces/IMember.sol';
 import '../interfaces/IVoting.sol';
 import '../../helpers/FlagHelper.sol';
 
-contract VotingContract is IVoting {
-
-    bytes32 constant MEMBER_MODULE = keccak256("member");
+contract VotingContract is IVoting, Module {
 
     using FlagHelper for uint256;
 

--- a/contracts/v3/guards/AdapterGuard.sol
+++ b/contracts/v3/guards/AdapterGuard.sol
@@ -4,14 +4,13 @@ pragma solidity ^0.7.0;
 
 import '../core/Registry.sol';
 import '../core/interfaces/IMember.sol';
+import '../core/Module.sol';
 
 /**
  * @dev Contract module that helps restrict the adapter access to DAO Members only.
  *
  */
-abstract contract AdapterGuard {
-
-    bytes32 constant MEMBER_MODULE = keccak256("member");
+abstract contract AdapterGuard is Module {
 
     /**
      * @dev Only members of the Guild are allowed to execute the function call.

--- a/test/financing.test.js
+++ b/test/financing.test.js
@@ -38,7 +38,7 @@ async function advanceTime(time) {
     });
 }
 
-contract('MolochV3 - Financing', async accounts => {
+contract('MolochV3 - Financing Adapter', async accounts => {
 
   const numberOfShares = Web3.toBN('1000000000000000');
   const sharePrice = Web3.toBN(Web3.toWei("120", 'finney'));

--- a/test/managing.test.js
+++ b/test/managing.test.js
@@ -1,0 +1,216 @@
+
+const Web3 = require('web3-utils');
+const FlagHelperLib = artifacts.require('./v3/helpers/FlagHelper');
+const DaoFactory = artifacts.require('./v3/core/DaoFactory');
+const ModuleRegistry = artifacts.require('./v3/core/Registry');
+const MemberContract = artifacts.require('./v3/core/MemberContract');
+const VotingContract = artifacts.require('./v3/core/VotingContract');
+const ProposalContract = artifacts.require('./v3/core/ProposalContract');
+const ManagingContract = artifacts.require('./v3/adapters/ManagingContract');
+
+async function advanceTime(time) {
+  await new Promise((resolve, reject) => {
+    web3.currentProvider.send({
+      jsonrpc: '2.0',
+      method: 'evm_increaseTime',
+      params: [time],
+      id: new Date().getTime()
+    }, (err, result) => {
+      if (err) { return reject(err) }
+      return resolve(result)
+    })
+  });
+
+  await new Promise((resolve, reject) => {
+      web3.currentProvider.send({
+          jsonrpc: '2.0',
+          method: 'evm_mine',
+          id: new Date().getTime()
+      }, (err, result) => {
+        if (err) { return reject(err) }
+        return resolve(result)
+      })
+    });
+}
+
+contract('MolochV3 - Managing Adapter', async accounts => {
+
+  const GUILD = "0x000000000000000000000000000000000000dead";
+  const ESCROW = "0x000000000000000000000000000000000000beef";
+  const TOTAL = "0x000000000000000000000000000000000000babe";
+
+  const numberOfShares = Web3.toBN('1000000000000000');
+  const sharePrice = Web3.toBN(Web3.toWei("120", 'finney'));
+
+  async function prepareSmartContracts() {
+    let lib = await FlagHelperLib.new();
+    await MemberContract.link("FlagHelper", lib.address);
+    await ProposalContract.link("FlagHelper", lib.address);
+    let member = await MemberContract.new();
+    let proposal = await ProposalContract.new();
+    let voting = await VotingContract.new();
+    return { voting, proposal, member};
+  }
+
+  async function createDao(member, proposal, voting, senderAccount) {
+    let daoFactory = await DaoFactory.new(member.address, proposal.address, voting.address,
+      { from: senderAccount, gasPrice: Web3.toBN("0") });
+    await daoFactory.newDao(sharePrice, numberOfShares, 1000, { from: senderAccount, gasPrice: Web3.toBN("0") });
+    let pastEvents = await daoFactory.getPastEvents();
+    let daoAddress = pastEvents[0].returnValues.dao;
+    let dao = await ModuleRegistry.at(daoAddress);
+    return dao;
+  }
+
+  it("should not be possible to change the DAO Managing module", async () => {
+    const myAccount = accounts[1];
+    const applicant = accounts[2];
+    const { voting, member, proposal } = await prepareSmartContracts();
+
+    //Create the new DAO
+    let dao = await createDao(member, proposal, voting, myAccount);
+
+    //Submit a new Bank module proposal
+    let managingAddress = await dao.getAddress(Web3.sha3('managing'));
+    let managing = await ManagingContract.at(managingAddress);
+    let newModuleId = Web3.sha3('managing');
+    let newModuleAddress = accounts[3];
+
+    try {
+      await managing.createModuleChangeRequest(applicant, newModuleId, newModuleAddress);
+    } catch (err) {
+      assert.equal(err.reason, "module not replaceable");
+    }
+  })
+
+  it("should not be possible to propose a new module with 0x0 module address", async () => {
+    const myAccount = accounts[1];
+    const applicant = accounts[2];
+    const { voting, member, proposal } = await prepareSmartContracts();
+
+    //Create the new DAO
+    let dao = await createDao(member, proposal, voting, myAccount);
+
+    //Submit a new Bank module proposal
+    let managingAddress = await dao.getAddress(Web3.sha3('managing'));
+    let managing = await ManagingContract.at(managingAddress);
+    let newModuleId = Web3.sha3('bank');
+
+    try {
+      await managing.createModuleChangeRequest(applicant, newModuleId, "0x0000000000000000000000000000000000000000");
+    } catch (err) {
+      assert.equal(err.reason, "invalid module address");
+    }
+
+  })
+
+  it("should not be possible to propose a new module when the applicant has a reserved address", async () => {
+    const myAccount = accounts[1];
+    const applicant = accounts[2];
+    const { voting, member, proposal } = await prepareSmartContracts();
+
+    //Create the new DAO
+    let dao = await createDao(member, proposal, voting, myAccount);
+
+    //Submit a new Bank module proposal
+    let managingAddress = await dao.getAddress(Web3.sha3('managing'));
+    let managing = await ManagingContract.at(managingAddress);
+    let newModuleId = Web3.sha3('bank');
+
+    try {
+      await managing.createModuleChangeRequest(GUILD, newModuleId, accounts[3]);
+    } catch (err) {
+      assert.equal(err.reason, "applicant address cannot be reserved");
+    }
+    try {
+      await managing.createModuleChangeRequest(ESCROW, newModuleId, accounts[3]);
+    } catch (err) {
+      assert.equal(err.reason, "applicant address cannot be reserved");
+    }
+    try {
+      await managing.createModuleChangeRequest(TOTAL, newModuleId, accounts[3]);
+    } catch (err) {
+      assert.equal(err.reason, "applicant address cannot be reserved");
+    }
+  })
+
+  it("should not be possible to propose a new module when the module has a reserved address", async () => {
+    const myAccount = accounts[1];
+    const applicant = accounts[2];
+    const { voting, member, proposal } = await prepareSmartContracts();
+
+    //Create the new DAO
+    let dao = await createDao(member, proposal, voting, myAccount);
+
+    //Submit a new Bank module proposal
+    let managingAddress = await dao.getAddress(Web3.sha3('managing'));
+    let managing = await ManagingContract.at(managingAddress);
+    let newModuleId = Web3.sha3('bank');
+
+    try {
+      await managing.createModuleChangeRequest(applicant, newModuleId, GUILD);
+    } catch (err) {
+      assert.equal(err.reason, "module address cannot be reserved");
+    }
+    try {
+      await managing.createModuleChangeRequest(applicant, newModuleId, ESCROW);
+    } catch (err) {
+      assert.equal(err.reason, "module address cannot be reserved");
+    }
+    try {
+      await managing.createModuleChangeRequest(applicant, newModuleId, TOTAL);
+    } catch (err) {
+      assert.equal(err.reason, "module address cannot be reserved");
+    }
+  })
+
+  it("should not be possible to propose a new module with an empty module address", async () => {
+    const myAccount = accounts[1];
+    const applicant = accounts[2];
+    const { voting, member, proposal } = await prepareSmartContracts();
+
+    //Create the new DAO
+    let dao = await createDao(member, proposal, voting, myAccount);
+
+    //Submit a new Bank module proposal
+    let managingAddress = await dao.getAddress(Web3.sha3('managing'));
+    let managing = await ManagingContract.at(managingAddress);
+    let newModuleId = Web3.sha3('managing');
+
+    try {
+      await managing.createModuleChangeRequest(applicant, newModuleId, "");
+    } catch (err) {
+      assert.equal(err.reason, "invalid address");
+    }
+  })
+
+  it("should be possible to any individual to propose a new DAO Banking module", async () => {
+    const myAccount = accounts[1];
+    const applicant = accounts[2];
+    const { voting, member, proposal } = await prepareSmartContracts();
+
+    //Create the new DAO
+    let dao = await createDao(member, proposal, voting, myAccount);
+
+    //Submit a new Bank module proposal
+    let managingAddress = await dao.getAddress(Web3.sha3('managing'));
+    let managing = await ManagingContract.at(managingAddress);
+    let newModuleId = Web3.sha3('bank');
+    let newModuleAddress = accounts[3]; //TODO deploy some Banking test contract
+    await managing.createModuleChangeRequest(applicant, newModuleId, newModuleAddress);
+
+    //Get the new proposal id
+    pastEvents = await proposal.getPastEvents();
+    let { proposalId } = pastEvents[0].returnValues;
+    
+    //Sponsor the new proposal, vote and process it 
+    await managing.sponsorProposal(proposalId, [], { from: myAccount, gasPrice: Web3.toBN("0") });
+    await voting.submitVote(dao.address, proposalId, 1, { from: myAccount, gasPrice: Web3.toBN("0") });
+    await advanceTime(10000);
+    await managing.processProposal(proposalId, { from: myAccount, gasPrice: Web3.toBN("0") });
+
+    //Check if the Bank Module was added to the Registry
+    let newBankAddress = await dao.getAddress(Web3.sha3('bank'));
+    assert.equal(newBankAddress.toString(), newModuleAddress.toString());
+  })
+});

--- a/test/managing.test.js
+++ b/test/managing.test.js
@@ -62,27 +62,6 @@ contract('MolochV3 - Managing Adapter', async accounts => {
     return dao;
   }
 
-  it("should not be possible to change the DAO Managing module", async () => {
-    const myAccount = accounts[1];
-    const applicant = accounts[2];
-    const { voting, member, proposal } = await prepareSmartContracts();
-
-    //Create the new DAO
-    let dao = await createDao(member, proposal, voting, myAccount);
-
-    //Submit a new Bank module proposal
-    let managingAddress = await dao.getAddress(Web3.sha3('managing'));
-    let managing = await ManagingContract.at(managingAddress);
-    let newModuleId = Web3.sha3('managing');
-    let newModuleAddress = accounts[3];
-
-    try {
-      await managing.createModuleChangeRequest(applicant, newModuleId, newModuleAddress);
-    } catch (err) {
-      assert.equal(err.reason, "module not replaceable");
-    }
-  })
-
   it("should not be possible to propose a new module with 0x0 module address", async () => {
     const myAccount = accounts[1];
     const applicant = accounts[2];

--- a/test/onboarding.test.js
+++ b/test/onboarding.test.js
@@ -39,7 +39,7 @@ async function advanceTime(time) {
     });
 }
 
-contract('MolochV3 - Onboarding', async accounts => {
+contract('MolochV3 - Onboarding Adapter', async accounts => {
 
   const numberOfShares = Web3.toBN('1000000000000000');
   const sharePrice = Web3.toBN(Web3.toWei("120", 'finney'));

--- a/test/registry_unit_test.js
+++ b/test/registry_unit_test.js
@@ -1,7 +1,7 @@
 const Web3 = require('web3-utils');
 const ModuleRegistry = artifacts.require('./v3/core/Registry');
 
-contract('Registry', async accounts => {
+contract('Registry', async () => {
 
   it("should not be possible to create a dao with an invalid module id", async () => {
     let moduleId = Web3.fromUtf8("");
@@ -10,7 +10,7 @@ contract('Registry', async accounts => {
     try {
       await contract.addModule(moduleId, moduleAddress);
     } catch (err) {
-      assert.equal(err.reason, "moduleId must not be empty");
+      assert.equal(err.reason, "module id must not be empty");
     }
   });
 
@@ -20,7 +20,7 @@ contract('Registry', async accounts => {
     try {
       await contract.removeModule(moduleId);
     } catch (err) {
-      assert.equal(err.reason, "moduleId not registered");
+      assert.equal(err.reason, "module id not registered");
     }
   });
 
@@ -37,12 +37,12 @@ contract('Registry', async accounts => {
 
   it("should not be possible to create a dao with an empty module address", async () => {
     let moduleId = Web3.fromUtf8("1");
-    let moduleAddress = "0x0";
+    let moduleAddress = "0x0000000000000000000000000000000000000000";
     let contract = await ModuleRegistry.new();
     try {
       await contract.addModule(moduleId, moduleAddress);
     } catch (err) {
-      assert.equal(err.reason, "invalid address");
+      assert.equal(err.reason, "module address must not be empty");
     }
   });
 

--- a/test/registry_unit_test.js
+++ b/test/registry_unit_test.js
@@ -8,7 +8,7 @@ contract('Registry', async accounts => {
     let moduleAddress = "0x627306090abaB3A6e1400e9345bC60c78a8BEf57";
     let contract = await ModuleRegistry.new();
     try {
-      await contract.updateRegistry(moduleId, moduleAddress);
+      await contract.addModule(moduleId, moduleAddress);
     } catch (err) {
       assert.equal(err.reason, "moduleId must not be empty");
     }
@@ -18,7 +18,7 @@ contract('Registry', async accounts => {
     let moduleId = Web3.fromUtf8("1");
     let contract = await ModuleRegistry.new();
     try {
-      await contract.removeRegistry(moduleId);
+      await contract.removeModule(moduleId);
     } catch (err) {
       assert.equal(err.reason, "moduleId not registered");
     }
@@ -29,7 +29,7 @@ contract('Registry', async accounts => {
     let moduleAddress = "";
     let contract = await ModuleRegistry.new();
     try {
-      await contract.updateRegistry(moduleId, moduleAddress);
+      await contract.addModule(moduleId, moduleAddress);
     } catch (err) {
       assert.equal(err.reason, "invalid address");
     }
@@ -40,7 +40,7 @@ contract('Registry', async accounts => {
     let moduleAddress = "0x0";
     let contract = await ModuleRegistry.new();
     try {
-      await contract.updateRegistry(moduleId, moduleAddress);
+      await contract.addModule(moduleId, moduleAddress);
     } catch (err) {
       assert.equal(err.reason, "invalid address");
     }
@@ -50,7 +50,7 @@ contract('Registry', async accounts => {
     let moduleId = Web3.fromUtf8("1");
     let moduleAddress = "0x627306090abaB3A6e1400e9345bC60c78a8BEf57";
     let contract = await ModuleRegistry.new();
-    await contract.updateRegistry(moduleId, moduleAddress);
+    await contract.addModule(moduleId, moduleAddress);
     let address = await contract.getAddress(moduleId);
     assert.equal(address, moduleAddress);
   });
@@ -59,10 +59,10 @@ contract('Registry', async accounts => {
     let moduleId = Web3.fromUtf8("2");
     let moduleAddress = "0x627306090abaB3A6e1400e9345bC60c78a8BEf57";
     let contract = await ModuleRegistry.new();
-    await contract.updateRegistry(moduleId, moduleAddress);
+    await contract.addModule(moduleId, moduleAddress);
     let address = await contract.getAddress(moduleId);
     assert.equal(address, moduleAddress);
-    await contract.removeRegistry(moduleId);
+    await contract.removeModule(moduleId);
     address = await contract.getAddress(moduleId);
     assert.equal(address, "0x0000000000000000000000000000000000000000");
   });


### PR DESCRIPTION
Initial version of the Managing Adapter which allows people to propose new DAO Modules.

- The only module not replaceable is the `Managing` module to prevent the issue where someone try to replace the module that manages the communication with the DAO registry
- All other modules are free to be replaced: bank, member, financing, onboarding, voting and proposal
- Need to double check with @adridadou if we want to allow that all modules as replaceable or restrict it to only core (need to think carefully about the implications and security issues that my come up if we allow to replace any module of the DAO) 
- Added some unit and use-case tests
- Minor refactor to make the module names available in a abstract contract so we can eliminate the duplicate module names

TODO 
- Adding more tests to cover each module that can be replaced
- Figure out a way to check if a new module implements the interface that it is supposed to implement 
  - is it feasible?
  - do we really need that?
  - is it possible that someone submits a new Bank module proposal but the module is not really a Bank?
  - how do we want to handle that? 